### PR TITLE
Linksnail upgrade

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2016-04-08  debug-ito <debug.ito@gmail.com>
+
+	* linksnail.ks.js 0.2.0:
+	- Use "{}" in format texts. This makes the formatting more robust
+	especially when "text" is included in the URI.
+
+	- Now formats are configurable via option `linksnail.formats`.
+
+	- A Function can now be used to format the link.
+
 2009-10-06  gongo  <gonngo@gmail.com>
 
 	* excite_translation.js: TODO

--- a/linksnail.ks.js
+++ b/linksnail.ks.js
@@ -59,13 +59,13 @@ key.setGlobalKey(['C-c', 't'], function (ev, arg) {
 var linksnail =
     (function() {
         var formatCollection = [
-            ["Markdown"         , "[text](uri)"],
-            ["Org-mode"         , "[[uri][text]]"],
-            ["Textile"          , "\"text\":uri"],
-            ["reStructuredText" , "`text` <uri>"],
-            ["HTML"             , "<a href=\"uri\">text</a>"],
-            ["Plain"            , "text / uri"],
-            ["URI"              , "uri"],
+            ["Markdown"         , "[{text}]({uri})"],
+            ["Org-mode"         , "[[{uri}][{text}]]"],
+            ["Textile"          , "\"{text}\":{uri}"],
+            ["reStructuredText" , "`{text}` <{uri}>"],
+            ["HTML"             , "<a href=\"{uri}\">{text}</a>"],
+            ["Plain"            , "{text} / {uri}"],
+            ["URI"              , "{uri}"],
         ];
 
         function copyLink(link){
@@ -78,8 +78,8 @@ var linksnail =
 
         function formatTextAndURI(format, text, uri){
             var link = "";
-            link = format.replace("uri", uri);
-            link = link.replace("text", text);
+            link = format.replace("{uri}", uri);
+            link = link.replace("{text}", text);
             return link;
         };
 

--- a/linksnail.ks.js
+++ b/linksnail.ks.js
@@ -5,7 +5,7 @@ var PLUGIN_INFO =
     <updateURL>https://raw.github.com/gongo/keysnail_plugin/master/linksnail.ks.js</updateURL>
     <description>Get link on the page currently open for Variety format (Markdown, org-mode, etc..)</description>
     <description lang="ja">現在開いているページへのリンクを、様々な形式 (Markdown や org-mode など)で取得します</description>
-    <version>0.1.1</version>
+    <version>0.2.0</version>
     <author mail="gonngo@gmail.com" homepage="http://d.hatena.ne.jp/gongoZ/">gongoZ</author>
     <license>MAHALO License</license>
     <license lang="ja">MAHALO ライセンス</license>

--- a/linksnail.ks.js
+++ b/linksnail.ks.js
@@ -78,8 +78,8 @@ var linksnail =
 
         function formatTextAndURI(format, text, uri){
             var link = "";
-            link = format.replace("{uri}", uri);
-            link = link.replace("{text}", text);
+            link = format.replace(/\{uri\}/g, uri);
+            link = link.replace(/\{text\}/g, text);
             return link;
         };
 

--- a/linksnail.ks.js
+++ b/linksnail.ks.js
@@ -56,17 +56,33 @@ key.setGlobalKey(['C-c', 't'], function (ev, arg) {
     ]]></detail>
 </KeySnailPlugin>;
 
+var pOptions = plugins.setupOptions("linksnail", {
+    "formats": {
+        preset: {
+            "Markdown": "[{text}]({uri})",
+            "Org-mode": "[[{uri}][{text}]]",
+            "Textile": "\"{text}\":{uri}",
+            "reStructuredText": "`{text}` <{uri}>",
+            "HTML": "<a href=\"{uri}\">{text}</a>",
+            "Plain": "{text} / {uri}",
+            "URI": "{uri}"
+        },
+        description: M({
+            en: "Link formats",
+            jp: "リンクフォーマット"
+        }),
+        type: "object ({format_name: format})"
+    }
+}, PLUGIN_INFO);
+
+
 var linksnail =
     (function() {
-        var formatCollection = [
-            ["Markdown"         , "[{text}]({uri})"],
-            ["Org-mode"         , "[[{uri}][{text}]]"],
-            ["Textile"          , "\"{text}\":{uri}"],
-            ["reStructuredText" , "`{text}` <{uri}>"],
-            ["HTML"             , "<a href=\"{uri}\">{text}</a>"],
-            ["Plain"            , "{text} / {uri}"],
-            ["URI"              , "{uri}"],
-        ];
+        function getFormatCollection() {
+            return Object.keys(pOptions["formats"]).map(function(format_name) {
+                return [format_name, pOptions["formats"][format_name]];
+            });
+        };
 
         function copyLink(link){
             const CLIPBOARD = Components.classes[
@@ -86,7 +102,7 @@ var linksnail =
         function formatSelector(next) {
             prompt.selector({
                 message    : "Select format",
-                collection : formatCollection,
+                collection : getFormatCollection(),
                 header     : ["name", "syntax"],
                 callback   : next,
             });
@@ -94,17 +110,17 @@ var linksnail =
 
         var self = {
             copyThisPage : function() {
-                formatSelector(function(index){
+                formatSelector(function(index, collection){
                     var uri    = content.location.href;
                     var text   = content.document.title;
-                    var format = formatCollection[index][1];
+                    var format = collection[index][1];
 
                     copyLink(formatTextAndURI(format, text, uri));
                 });
             },
             copyAllPage : function() {
-                formatSelector(function(index){
-                    var format = formatCollection[index][1];
+                formatSelector(function(index, collection){
+                    var format = collection[index][1];
                     var a = [(function(){
                         var browser = tab.linkedBrowser;
                         var win     = browser.contentWindow;

--- a/linksnail.ks.js
+++ b/linksnail.ks.js
@@ -12,8 +12,8 @@ var PLUGIN_INFO =
     <include>main</include>
     <detail><![CDATA[
 === Overview ===
-Get link on the page currently open for Variety format (Markdown, org-mode, etc..).
-And copies it to the clipboard.
+Get a link to the page currently open in a variety of formats (Markdown, org-mode, etc..),
+and copy it to the clipboard.
 It is also possible to get and copy links of all the tabs on current window.
 
 === Support Format ===


### PR DESCRIPTION
Some upgrades in linksnail.ks.js.

- Use "{}" in format texts. This makes the formatting more robust especially when "text" is included in the URI.
- Now formats are configurable via option `linksnail.formats`.
- A Function can now be used to format the link.

